### PR TITLE
Find Clang library on mac

### DIFF
--- a/src/CIG-LibClang/LibClang.class.st
+++ b/src/CIG-LibClang/LibClang.class.st
@@ -11,6 +11,16 @@ LibClang class >> options [
 	^ #( -optStrict )
 ]
 
+{ #category : 'accessing - platform' }
+LibClang >> macLibraryName [
+
+	^ FFIMacLibraryFinder new
+		  userPaths:
+			  #( '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib'
+			     '/Library/Developer/CommandLineTools/usr/lib' );
+		  findLibrary: 'libclang.dylib'
+]
+
 { #category : 'accessing' }
 LibClang >> runner [
 


### PR DESCRIPTION
Use common paths where the Clang library would usually be located on macOS.