### PR TITLE
Method generation: Add a return if the element isReturnTypeVoid not

### DIFF
--- a/src/CIG-Tests/CigPharoFunctionTemplateTest.class.st
+++ b/src/CIG-Tests/CigPharoFunctionTemplateTest.class.st
@@ -74,7 +74,7 @@ CigPharoFunctionTemplateTest >> testGenerateFunctionWithReturnString [
 		assert: template generate
 		equals: 'fadeColor: color alpha: alpha
 
-	self ffiCall: #(Color Fade(Color color, float alpha))'
+	^ self ffiCall: #(Color Fade(Color color, float alpha))'
 ]
 
 { #category : 'tests' }
@@ -102,7 +102,7 @@ CigPharoFunctionTemplateTest >> testGenerateMethod [
 		assert: template generate
 		equals: 'getBounds
 
-	self ffiCall: #(xx_TRect* xx_TView_getBounds(xx_TView* self))'
+	^ self ffiCall: #(xx_TRect* xx_TView_getBounds(xx_TView* self))'
 ]
 
 { #category : 'tests' }
@@ -116,5 +116,5 @@ CigPharoFunctionTemplateTest >> testGenerateMethodWithResultAsArgument [
 		assert: template generate
 		equals: 'getColor: color result: result
 
-	self ffiCall: #(void xx_TView_getColor(xx_TView* self, xx_ushort color, xx_TAttrPair* result))'
+	^ self ffiCall: #(void xx_TView_getColor(xx_TView* self, xx_ushort color, xx_TAttrPair* result))'
 ]

--- a/src/CIG/CigPharoFunctionTemplate.class.st
+++ b/src/CIG/CigPharoFunctionTemplate.class.st
@@ -46,6 +46,7 @@ CigPharoFunctionTemplate >> generate [
 			ifTrue: [ stream << self generateComment; cr ].
 		stream cr.
 		stream tab.
+		self element isReturnTypeVoid ifFalse: [ stream nextPutAll: '^ ' ].
 		stream << 'self ffiCall: #(' << self element cTemplate generateHeaderForFFI << ')' ]
 ]
 


### PR DESCRIPTION
@estebanlm for testGenerateFunctionWithReturnString it makes sense, but for the other 2 tests... I don't understand well why they return void but anyway the answer false to isReturnTypeVoid. However, the return doesn't hurt in those cases.