### PR TITLE
add constant generation capabilities

### DIFF
--- a/src/CIG-LibClang/CXCursor.class.st
+++ b/src/CIG-LibClang/CXCursor.class.st
@@ -487,14 +487,6 @@ CXCursor >> source [
 	^ source trimmed
 ]
 
-{ #category : 'accessing - tokens' }
-CXCursor >> sourceTokens [
-	| range |
-	
-	range := self clang_getCursorExtent.	
-	^ self translationUnit tokensOfRange: range
-]
-
 { #category : 'accessing' }
 CXCursor >> spelling [
 	| string |
@@ -568,10 +560,10 @@ CXCursor >> withAllSemanticParents [
 ]
 
 { #category : 'accessing - tokens' }
-CXCursor >> wthSourceTokensDo: aBlock [
+CXCursor >> withSourceTokensDo: aBlock [
 	| range |
 	
-	range := self clang_getCursorExtent.	
+	range := self clang_getCursorExtent.
 	^ self translationUnit 
 		withTokensOfRange: range 
 		do: aBlock

--- a/src/CIG-LibClang/CXTranslationUnit.class.st
+++ b/src/CIG-LibClang/CXTranslationUnit.class.st
@@ -129,7 +129,7 @@ CXTranslationUnit >> clang_disposeTokens: tokens numTokens: numTokens [
 
 	^ self ffiCall: #(void clang_disposeTokens(
 		CXTranslationUnit self,
-		"CXToken *"void *tokens,
+		CXToken *tokens,
 		uint numTokens))
 ]
 
@@ -151,6 +151,16 @@ CXTranslationUnit >> clang_getTokenSpelling: token [
 	self ffiCall: #(CXString clang_getTokenSpelling(
 		CXTranslationUnit self,
 		CXToken token))
+]
+
+{ #category : 'private' }
+CXTranslationUnit >> clang_tokenize: range tokens: tokens numTokens: numTokens [
+
+	^ self ffiCall: #(void clang_tokenize (
+		CXTranslationUnit self,
+		CXSourceRange range,
+		CXToken **tokens,
+		uint *numTokens))
 ]
 
 { #category : 'accessing - cursor' }
@@ -177,19 +187,6 @@ CXTranslationUnit >> dispose [
 ]
 
 { #category : 'accessing - tokens' }
-CXTranslationUnit >> disposeTokens: aCollection [
-	| array |
-	
-	aCollection isEmptyOrNil ifTrue: [ ^ self ].
-	
-	array := FFITypeArray newType: #'void*' size: aCollection size.
-	aCollection withIndexDo: [ :each :index |
-		array at: index put: each getHandle ].
-	
-	self clang_disposeTokens: array getHandle numTokens: aCollection size
-]
-
-{ #category : 'accessing - tokens' }
 CXTranslationUnit >> tokenSpelling: token [
 	| string |
 	
@@ -198,38 +195,27 @@ CXTranslationUnit >> tokenSpelling: token [
 		ensure: [ string dispose ]
 ]
 
-{ #category : 'private' }
-CXTranslationUnit >> tokenize: range tokens: tokens numTokens: numTokens [
-
-	^ self ffiCall: #(void clang_tokenize (
-		CXTranslationUnit self,
-		CXSourceRange range,
-		"CXToken **"void **tokens,
-		"unsigned *"void *numTokens))
-]
-
-{ #category : 'accessing - tokens' }
-CXTranslationUnit >> tokensOfRange: range [
-	| tokensBuffer numTokensBuffer count |
-	
-	tokensBuffer := ExternalAddress new.
-	numTokensBuffer := FFIUInt32 newBuffer.
-
-	self tokenize: range tokens: tokensBuffer numTokens: numTokensBuffer.
-	count := numTokensBuffer unsignedLongAt: 1.
-	count = 0 ifTrue: [ ^ #() ].
-
-	^ Array streamContents: [ :stream |
-		0 to: (count - 1) do: [ :index |
-			stream nextPut: (CXToken fromHandle: (tokensBuffer pointerAtOffset: index * FFIExternalType pointerSize)) ] ]
-]
-
 { #category : 'accessing - tokens' }
 CXTranslationUnit >> withTokensOfRange: range do: aBlock [
-	| tokens |
+	| tokensHolder tokens numTokensHolder count |
 	
-	tokens := self tokensOfRange: range.
-	[ aBlock value: tokens ]
+	"since CXToken is a structure, but we get pointers to it"
+	tokensHolder := CXToken newValueHolder.
+	numTokensHolder := FFIUInt32 newValueHolder.
+
+	self 
+		clang_tokenize: range
+		tokens: tokensHolder
+		numTokens: numTokensHolder.
+	count := numTokensHolder value.
+	count = 0 ifTrue: [ 
+		aBlock cull: nil cull: 0.
+		^ self ].
+	tokens := tokensHolder arrayOfSize: count.
+	
+	^ [ aBlock cull: tokens cull: count ]
 	ensure: [ 
-		self disposeTokens: tokens ]
+		self 
+			clang_disposeTokens: tokensHolder value
+			numTokens: count ]
 ]

--- a/src/CIG-Tests/CigPharoBaseTest.class.st
+++ b/src/CIG-Tests/CigPharoBaseTest.class.st
@@ -12,6 +12,16 @@ CigPharoBaseTest class >> isAbstract [
 	^ super isAbstract or: [ self = CigPharoBaseTest ]
 ]
 
+{ #category : 'instance creation' }
+CigPharoBaseTest >> newUnit: aString [
+
+	^ CigCLibraryGenerator new 
+		packageName: 'Unit';
+		prefix: 'Unit';
+		importUnit: aString;
+		translateUnit
+]
+
 { #category : 'running' }
 CigPharoBaseTest >> tearDown [
 

--- a/src/CIG-Tests/CigPharoConstantsPoolGeneratorTest.class.st
+++ b/src/CIG-Tests/CigPharoConstantsPoolGeneratorTest.class.st
@@ -1,0 +1,101 @@
+Class {
+	#name : 'CigPharoConstantsPoolGeneratorTest',
+	#superclass : 'TestCase',
+	#category : 'CIG-Tests-Pharo',
+	#package : 'CIG-Tests',
+	#tag : 'Pharo'
+}
+
+{ #category : 'running' }
+CigPharoConstantsPoolGeneratorTest >> tearDown [
+
+	'./CIG/unittotest' asFileReference ensureDeleteAll.
+	PackageOrganizer default 
+		packageNamed: #UnitToTest
+		ifPresent: [ :aPackage | aPackage removeFromSystem ].
+		
+	super tearDown
+]
+
+{ #category : 'tests' }
+CigPharoConstantsPoolGeneratorTest >> testAddClassWithConstants [
+	| gen file unit result |
+
+	file := CigCLibraryGenerator new 
+		packageName: 'UnitToTest';
+		libraryName: 'unittotest';
+		importUnit: '
+#define MACRO 42
+#define MACRO_STRING "Hello, World"
+#define MACRO_CHAR ''A''';
+		yourself.
+		
+	unit := file translateUnit.
+
+	gen := CigPharoConstantsPoolGenerator newFile: file unit: unit. 
+
+	gen addClassWithConstants: #('MACRO' 'MACRO_STRING' 'MACRO_CHAR').
+	result := gen generatedClass.
+
+	self assert: result name equals: 'UnittotestConstants'.
+	self assert: result classPool size equals: 3
+]
+
+{ #category : 'tests' }
+CigPharoConstantsPoolGeneratorTest >> testCollectConstantValues [
+	| gen file unit result |
+
+	file := CigCLibraryGenerator new 
+		packageName: 'UnitToTest';
+		libraryName: 'unittotest';
+		importUnit: '
+#define MACRO 42
+#define MACRO_STRING "Hello, World"
+#define MACRO_CHAR ''A''';
+		yourself.
+		
+	unit := file translateUnit.
+
+	gen := CigPharoConstantsPoolGenerator newFile: file unit: unit. 
+
+	result := gen collectConstantValues: #('MACRO' 'MACRO_STRING' 'MACRO_CHAR').
+
+	self assert: (result at: 'MACRO') equals: 42.
+	self assert: (result at: 'MACRO_STRING') equals: 'Hello, World'.	
+	self assert: (result at: 'MACRO_CHAR') equals: 65
+]
+
+{ #category : 'tests' }
+CigPharoConstantsPoolGeneratorTest >> testGenerateConstants [
+	| gen file unit result |
+
+	file := CigCLibraryGenerator new 
+		packageName: 'UnitToTest';
+		libraryName: 'unittotest';
+		importUnit: '
+#define MACRO 42
+#define MACRO_STRING "Hello, World"
+#define MACRO_CHAR ''A''';
+		yourself.
+		
+	unit := file translateUnit.
+
+	gen := CigPharoConstantsPoolGenerator newFile: file unit: unit. 
+
+	gen generateConstants: #('MACRO' 'MACRO_STRING' 'MACRO_CHAR').
+	result := gen generatedClass.
+
+	self assert: result name equals: 'UnittotestConstants'.
+	self assert: result classPool size equals: 3.
+	
+	self assert: result MACRO equals: 42.
+	self assert: result MACRO_STRING equals: 'Hello, World'.
+	self assert: result MACRO_CHAR equals: 65
+]
+
+{ #category : 'tests' }
+CigPharoConstantsPoolGeneratorTest >> testGenerateFileForImportingElements [
+
+	self fail.
+	CigPharoConstantsPoolGenerator new 
+]

--- a/src/CIG-Tests/CigPharoVisitor.extension.st
+++ b/src/CIG-Tests/CigPharoVisitor.extension.st
@@ -33,6 +33,7 @@ CigPharoVisitor >> prepareForTest [
 { #category : '*CIG-Tests' }
 CigPharoVisitor >> prepareForTestAsC [
 	
+	constants := OrderedCollection new.
 	types := Dictionary new.
 	file := CigCLibraryGenerator new
 		prefix: 'Gft';
@@ -45,6 +46,7 @@ CigPharoVisitor >> prepareForTestAsC [
 { #category : '*CIG-Tests' }
 CigPharoVisitor >> prepareForTestAsCPP [
 	
+	constants := OrderedCollection new.
 	types := Dictionary new.
 	file := CigCppLibraryGenerator new
 		prefix: 'Gft';

--- a/src/CIG-Tests/CigPharoVisitorTest.class.st
+++ b/src/CIG-Tests/CigPharoVisitorTest.class.st
@@ -434,6 +434,32 @@ CigPharoVisitorTest >> testVisitFunctionWithStructureGeneratesCallWithoutPrefix 
 	self ffiCall: #(void ClearBackground(Color color))'
 ]
 
+{ #category : 'tests - macro' }
+CigPharoVisitorTest >> testVisitMacroDefinition [
+	| unit element visitor |
+
+	unit := self newUnit: '#define MACRO 42'.
+	element := unit elements first.
+	
+	visitor := CigPharoVisitor newForTestAsC.	
+	visitor visitMacroDefinition: element.
+	
+	self assert: visitor constants asArray equals: #('MACRO')
+]
+
+{ #category : 'tests - macro' }
+CigPharoVisitorTest >> testVisitMacroDefinitionSkipsFunctionLike [
+	| unit element visitor |
+
+	unit := self newUnit: '#define MACRO(x) somefunction(x)'.
+	element := unit elements first.
+	
+	visitor := CigPharoVisitor newForTestAsC.	
+	visitor visitMacroDefinition: element.
+	
+	self assertEmpty: visitor constants
+]
+
 { #category : 'tests - method' }
 CigPharoVisitorTest >> testVisitMethodAddsClassMethodToClassSide [
 	| visitor class element |
@@ -824,8 +850,8 @@ CigPharoVisitorTest >> testVisitVariadic [
 		packageName: 'Unit';
 		prefix: 'Unit';
 		importUnit: '/* Nothing, I just want the variadics */';
-		declareVariadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
-		declareVariadic: 'int printf(char *fmt, long value)' as: #printf:long:;
+		variadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
+		variadic: 'int printf(char *fmt, long value)' as: #printf:long:;
 		translateUnit.
 	element := unit elementAtPath: { 'printf(char *fmt, char *value)' }. 
 	visitor := CigPharoVisitor newForTest.

--- a/src/CIG-Tests/CigVariadicFunctionTest.class.st
+++ b/src/CIG-Tests/CigVariadicFunctionTest.class.st
@@ -14,8 +14,8 @@ CigVariadicFunctionTest >> testGenerateVariadicFunction [
 		packageName: 'Unit';
 		prefix: 'Unit';
 		importUnit: '/* Nothing, I just want the variadics */';
-		declareVariadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
-		declareVariadic: 'int printf(char *fmt, long value)' as: #printf:long:;
+		variadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
+		variadic: 'int printf(char *fmt, long value)' as: #printf:long:;
 		translateUnit.
 
 	element := unit elements first.
@@ -44,8 +44,8 @@ CigVariadicFunctionTest >> testVariadicFunctionIsAddedToElementList [
 		packageName: 'Unit';
 		prefix: 'Unit';
 		importUnit: '/* Nothing, I just want the variadics */';
-		declareVariadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
-		declareVariadic: 'int printf(char *fmt, long value)' as: #printf:long:;
+		variadic: 'int printf(char *fmt, char *value)' as: #printf:string:;
+		variadic: 'int printf(char *fmt, long value)' as: #printf:long:;
 		translateUnit.
 
 	self assert: unit elements size equals: 2

--- a/src/CIG/CigCLibraryGenerator.class.st
+++ b/src/CIG/CigCLibraryGenerator.class.st
@@ -31,7 +31,6 @@ CigCLibraryGenerator >> generate [
 	logger trace: unit.
 	self hasClasses ifTrue: [ self generatePharoClassesWith: unit ].
 	self hasBaseline ifTrue: [ self generatePharoBaselineWith: unit ]
-	
 ]
 
 { #category : 'private' }

--- a/src/CIG/CigCommandExecutionError.class.st
+++ b/src/CIG/CigCommandExecutionError.class.st
@@ -1,0 +1,33 @@
+"
+This error happen when user tries to execute a command and for some reason the system is unable to complete it.
+It contains a `log` with the stderr output of the execution to provide some more information.
+"
+Class {
+	#name : 'CigCommandExecutionError',
+	#superclass : 'Error',
+	#instVars : [
+		'command',
+		'log'
+	],
+	#category : 'CIG-Pharo',
+	#package : 'CIG',
+	#tag : 'Pharo'
+}
+
+{ #category : 'accessing' }
+CigCommandExecutionError >> command: aString [
+
+	command := aString
+]
+
+{ #category : 'accessing' }
+CigCommandExecutionError >> log: aString [
+
+	log := aString
+]
+
+{ #category : 'accessing' }
+CigCommandExecutionError >> messageText [
+
+	^ 'Unable to execute {1}.' format: { command } 
+]

--- a/src/CIG/CigCommandExecutor.class.st
+++ b/src/CIG/CigCommandExecutor.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : 'CigCommandExecutor',
+	#superclass : 'Object',
+	#instVars : [
+		'home',
+		'command'
+	],
+	#category : 'CIG-Pharo',
+	#package : 'CIG',
+	#tag : 'Pharo'
+}
+
+{ #category : 'instance creation' }
+CigCommandExecutor class >> execute: aString [
+
+	^ (self newCommand: aString) execute
+]
+
+{ #category : 'instance creation' }
+CigCommandExecutor class >> newCommand: aString [
+
+	^ self new 
+		command: aString;
+		yourself
+]
+
+{ #category : 'accessing' }
+CigCommandExecutor >> command [
+
+	^ command
+]
+
+{ #category : 'accessing' }
+CigCommandExecutor >> command: aString [
+
+	command := aString
+]
+
+{ #category : 'executing' }
+CigCommandExecutor >> execute [
+	| result logReference |
+
+	logger trace: command.
+	
+	logReference := (self home / 'command-output.txt') ensureDelete.
+	result := LibC resultOfCommand: ('cd {1} && {2} 2> {3}' format: { 
+		self home fullName.
+		self command. 
+		logReference fullName }).
+	logReference exists ifTrue: [
+		| logError |
+		logError := logReference contents.
+		logError ifNotEmpty: [
+			logger error: 'Command not executed.'.
+			CigCommandExecutionError new 
+				command: command;
+				log: logError;
+				signal ] ].
+			
+	^ result
+]
+
+{ #category : 'accessing' }
+CigCommandExecutor >> home [
+
+	^ home ifNil: [ 
+		self home: FileLocator temp / 'CIG'.
+		home ]
+]
+
+{ #category : 'accessing' }
+CigCommandExecutor >> home: aStringOrReference [
+
+	home := aStringOrReference asFileReference ensureCreateDirectory
+]

--- a/src/CIG/CigConstantGenerator.class.st
+++ b/src/CIG/CigConstantGenerator.class.st
@@ -1,0 +1,59 @@
+"
+Define which headers to include to generate macros and rules to match them.
+Users can implement their own.
+"
+Class {
+	#name : 'CigConstantGenerator',
+	#superclass : 'Object',
+	#instVars : [
+		'headers',
+		'excludeMacros'
+	],
+	#category : 'CIG-Base',
+	#package : 'CIG',
+	#tag : 'Base'
+}
+
+{ #category : 'accessing' }
+CigConstantGenerator >> addHeader: aString [ 
+
+	headers ifNil: [ headers := #() ].
+	headers := headers copyWith: aString
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> excludeMacro: aString [
+
+	excludeMacros := excludeMacros copyWith: aString
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> excludeMacros: aCollection [
+
+	excludeMacros := aCollection
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> headers [
+
+	^ headers
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> headers: aCollection [
+
+	headers := aCollection
+]
+
+{ #category : 'initialization' }
+CigConstantGenerator >> initialize [
+
+	super initialize.
+	excludeMacros := #()
+]
+
+{ #category : 'testing' }
+CigConstantGenerator >> isPrintable: aMacroDefinition [
+
+	^ (excludeMacros includes: aMacroDefinition name) not
+]

--- a/src/CIG/CigConstantGenerator.class.st
+++ b/src/CIG/CigConstantGenerator.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'headers',
-		'excludeMacros'
+		'excludeMacros',
+		'printHex'
 	],
 	#category : 'CIG-Base',
 	#package : 'CIG',
@@ -21,8 +22,8 @@ CigConstantGenerator >> addHeader: aString [
 	headers := headers copyWith: aString
 ]
 
-{ #category : 'accessing' }
-CigConstantGenerator >> excludeMacro: aString [
+{ #category : 'accessing - scripting' }
+CigConstantGenerator >> exclude: aString [
 
 	excludeMacros := excludeMacros copyWith: aString
 ]
@@ -45,10 +46,17 @@ CigConstantGenerator >> headers: aCollection [
 	headers := aCollection
 ]
 
+{ #category : 'accessing - scripting' }
+CigConstantGenerator >> include: aString [ 
+
+	self addHeader: aString
+]
+
 { #category : 'initialization' }
 CigConstantGenerator >> initialize [
 
 	super initialize.
+	printHex := true.
 	excludeMacros := #()
 ]
 
@@ -56,4 +64,22 @@ CigConstantGenerator >> initialize [
 CigConstantGenerator >> isPrintable: aMacroDefinition [
 
 	^ (excludeMacros includes: aMacroDefinition name) not
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> printDecimal [
+
+	printHex := false
+]
+
+{ #category : 'accessing' }
+CigConstantGenerator >> printHex [
+
+	printHex := true
+]
+
+{ #category : 'testing' }
+CigConstantGenerator >> shouldPrintNumbersAsHex [
+
+	^ printHex
 ]

--- a/src/CIG/CigImportTarget.class.st
+++ b/src/CIG/CigImportTarget.class.st
@@ -54,5 +54,5 @@ CigImportTarget >> newTranslateUnitOn: aTranslateUnit header: aHeader [
 { #category : 'accessing' }
 CigImportTarget >> processNode: aCursor ifAdd: addBlock ifInsert: insertBlock [
 	
-	addBlock value
+	^ addBlock value
 ]

--- a/src/CIG/CigImportTargetFile.class.st
+++ b/src/CIG/CigImportTargetFile.class.st
@@ -56,5 +56,7 @@ CigImportTargetFile >> processNode: aCursor ifAdd: addBlock ifInsert: insertBloc
 
 	cppName := '::' join: aCursor lexicalPath.
 	(imports includes: cppName) 
-		ifTrue: [ insertBlock value ]
+		ifTrue: [ ^ insertBlock value ].
+		
+	^ nil
 ]

--- a/src/CIG/CigLibraryGenerator.class.st
+++ b/src/CIG/CigLibraryGenerator.class.st
@@ -36,7 +36,6 @@ Class {
 		'excluding',
 		'ffiRunner',
 		'typedefs',
-		'withPreprocessor',
 		'libraryName',
 		'unixLibraryName',
 		'macLibraryName',
@@ -44,7 +43,9 @@ Class {
 		'packageName',
 		'nameGenerator',
 		'withBaseline',
-		'variadics'
+		'variadics',
+		'withConstants',
+		'constantGenerator'
 	],
 	#category : 'CIG-Base',
 	#package : 'CIG',
@@ -245,13 +246,29 @@ CigLibraryGenerator >> cTypedefs: aCollectionOfAssociations [
 ]
 
 { #category : 'accessing - scripting' }
-CigLibraryGenerator >> declareVariadic: functionDeclaration as: aSelector [
+CigLibraryGenerator >> cVariadic: functionDeclaration as: aSelector [
 	"declare a variadic to be added to the function declaration.
 	 e.g. 
-	 lib declareVariadic: 'int printf(char *fmt, long value)' as: #printf:long: "
+	 lib cVariadic: 'int printf(char *fmt, long value)' as: #printf:long: "
 
 	variadics ifNil: [ variadics := OrderedDictionary new ].
 	variadics at: aSelector put: functionDeclaration
+]
+
+{ #category : 'accessing' }
+CigLibraryGenerator >> constantGenerator [
+
+	^ constantGenerator ifNil: [ constantGenerator := CigConstantGenerator new ]
+]
+
+{ #category : 'accessing - configuration' }
+CigLibraryGenerator >> constantGenerator: aConstantGenerator [
+	"Set the object that will be used to generate constants.
+	 The default will be a `CigConstantGenerator` instance, but users can provide their 
+	 own resolvers (Or configure the provided default)."
+	 
+	self withConstants.
+	constantGenerator := aConstantGenerator
 ]
 
 { #category : 'private' }
@@ -354,9 +371,9 @@ CigLibraryGenerator >> hasClasses [
 ]
 
 { #category : 'testing' }
-CigLibraryGenerator >> hasPreprocessor [
+CigLibraryGenerator >> hasConstants [
 
-	^ withPreprocessor
+	^ withConstants
 ]
 
 { #category : 'accessing - configuration' }
@@ -397,9 +414,10 @@ CigLibraryGenerator >> initialize [
 
 	super initialize.
 	imports := Dictionary new.
+
 	self withBaseline.
 	self withClasses.
-	self withoutPreprocessor.
+	self withConstants.
 	self useSameThread
 ]
 
@@ -591,7 +609,7 @@ CigLibraryGenerator >> variadics: aDictionary [
 	 The variadics arguments is dictionary of the form C Function -> Selector. 
 	 e.g.  'int printf(char *fmt, long number)' -> #printf:long:"
 
-	variadics := aDictionary
+	variadics := aDictionary asDictionary
 ]
 
 { #category : 'accessing - configuration' }
@@ -619,9 +637,14 @@ CigLibraryGenerator >> withClasses [
 ]
 
 { #category : 'accessing - configuration' }
-CigLibraryGenerator >> withPreprocessor [
+CigLibraryGenerator >> withConstants [
+	"Indicate the generator you want to generate a SharedPool named `LibraryNameConstants` 
+	 containing all the macro definitions we are able to parse (which is not ALL of them, 
+	 but it should be most of them).
+	 This does not includes function-like macros.
+	 DEFAULT: true"
 
-	withPreprocessor := true
+	withConstants := true
 ]
 
 { #category : 'accessing - configuration' }
@@ -637,7 +660,7 @@ CigLibraryGenerator >> withoutClasses [
 ]
 
 { #category : 'accessing - configuration' }
-CigLibraryGenerator >> withoutPreprocessor [
+CigLibraryGenerator >> withoutConstants [
 
-	withPreprocessor := false
+	withConstants := false
 ]

--- a/src/CIG/CigLibraryGenerator.class.st
+++ b/src/CIG/CigLibraryGenerator.class.st
@@ -344,8 +344,7 @@ CigLibraryGenerator >> generatePharoBaselineWith: aUnit [
 	<baseline>
 	
 	spec for: #common do: [
-		spec package: ''', self packageName, ''' 
-	]'
+		spec package: ''', self packageName, ''' ]'
 	classified: 'baselines'
 ]
 

--- a/src/CIG/CigMacroDefinition.class.st
+++ b/src/CIG/CigMacroDefinition.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'isBuiltin',
 		'isFunctionLike',
-		'source'
+		'source',
+		'isPrintable'
 	],
 	#category : 'CIG-Node',
 	#package : 'CIG',
@@ -19,7 +20,7 @@ CigMacroDefinition class >> kind [
 
 { #category : 'visiting' }
 CigMacroDefinition >> accept: aVisitor [
-
+	aVisitor visitMacroDefinition: self
 ]
 
 { #category : 'visiting' }
@@ -34,14 +35,17 @@ CigMacroDefinition >> acceptNameGenerator: aVisitor [
 CigMacroDefinition >> fromCursor: aCursor [
 
 	super fromCursor: aCursor.
+	name ifNil: [ name := aCursor displayName ].
 	isBuiltin := aCursor isMacroBuiltin.
 	isFunctionLike := aCursor isMacroFunctionLike.
 
-	self flag: #TODO. "I think this is better done with tokens (see sourceTokens and around). 
-	But for some reason it is crashing. Since I can achieve more or less the same and faster 
-	tokenising myself the source, I'll go that way for now."	
-	source := aCursor source 
-		ifNotNil: [ :aString | ' ' join: aString substrings allButFirst ]
+	"fast exit to not calculate the tokens of everything"
+	isFunctionLike ifTrue: [
+		isPrintable := false.
+		^ self ].
+
+	aCursor withSourceTokensDo: [ :tokens :numTokens |
+		isPrintable := numTokens > 1 and: [ tokens second isIdentifier not ] ]
 ]
 
 { #category : 'testing' }
@@ -54,6 +58,12 @@ CigMacroDefinition >> isFunctionLike [
 CigMacroDefinition >> isMacroDefinition [
 
 	^ true
+]
+
+{ #category : 'testing' }
+CigMacroDefinition >> isPrintable [
+
+	^ isPrintable
 ]
 
 { #category : 'accessing' }

--- a/src/CIG/CigPharoConstantsPoolGenerator.class.st
+++ b/src/CIG/CigPharoConstantsPoolGenerator.class.st
@@ -100,8 +100,14 @@ CigPharoConstantsPoolGenerator >> classInitializationTemplate: aDictionary [
 			do: [ :assoc | 
 				stream tab.
 				stream <<  assoc key << ' := '.
-				stream print: assoc value ]
-			separatedBy: [ stream << '.'; cr ] ]
+				"no point on print hex values of 0-9 values"
+				(assoc value isNumber 
+					and: [ self shouldPrintNumbersAsHex 
+					and: [ assoc value abs > 9 ] ])
+					ifTrue: [ stream << assoc value hex ]
+					ifFalse: [ stream print: assoc value ] ]
+			separatedBy: [ 
+				stream << '.'; cr ] ]
 ]
 
 { #category : 'private' }
@@ -243,4 +249,10 @@ CigPharoConstantsPoolGenerator >> generateConstants: aCollection [
 CigPharoConstantsPoolGenerator >> generatedClass [
 
 	^ generatedClass
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> shouldPrintNumbersAsHex [
+
+	^ self file constantGenerator shouldPrintNumbersAsHex
 ]

--- a/src/CIG/CigPharoConstantsPoolGenerator.class.st
+++ b/src/CIG/CigPharoConstantsPoolGenerator.class.st
@@ -58,7 +58,7 @@ CigPharoConstantsPoolGenerator class >> constantsTemplate [
 '
 ]
 
-{ #category : 'generating' }
+{ #category : 'private' }
 CigPharoConstantsPoolGenerator >> addClassAccessors: aCollection [
 
 	aCollection do: [ :each | 
@@ -117,7 +117,7 @@ CigPharoConstantsPoolGenerator >> collectConstantValues: aCollection [
 	macros := OrderedDictionary new.
 	fileReference := self generateCFileWith: aCollection.
 	binaryReference := self compileCFile: fileReference.
-	result := LibC resultOfCommand: binaryReference fullName.
+	result := self executeCommand: binaryReference.
 
 	result trimmed linesDo: [ :each | 
 		| tuple macroName |
@@ -157,11 +157,8 @@ CigPharoConstantsPoolGenerator >> compileCFile: fileReference [
 			self file cIncludePathsAsArguments
 				do: [ :each | stream << each ] 
 				separatedBy: [ stream space ] ] }.
-	logger trace: command.
-	result := LibC resultOfCommand: ('cd {1} && {2}' format: { 
-		fileReference parent fullName. 
-		command }).
-	logger trace: result.
+	
+	CigCommandExecutor execute: command. 
 
 	^ binaryReference
 ]
@@ -174,6 +171,14 @@ CigPharoConstantsPoolGenerator >> convert: aString to: typeString [
 	^ aString asNumber
 ]
 
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> executeCommand: binaryReference [
+
+	logger trace: binaryReference.
+	^ CigCommandExecutor execute: binaryReference fullName.	
+
+]
+
 { #category : 'generating' }
 CigPharoConstantsPoolGenerator >> generate [
 
@@ -184,9 +189,8 @@ CigPharoConstantsPoolGenerator >> generate [
 CigPharoConstantsPoolGenerator >> generateCFileWith: aCollection [
 	| fileReference |
 
-	fileReference := (FileLocator imageDirectory 
+	fileReference := (FileLocator temp 
 		/ 'CIG' 
-		/ self file libraryName 
 		/ (self file libraryName, '_constants')) 
 		withExtension: 'c'.
 	fileReference parent ensureCreateDirectory.

--- a/src/CIG/CigPharoConstantsPoolGenerator.class.st
+++ b/src/CIG/CigPharoConstantsPoolGenerator.class.st
@@ -1,0 +1,242 @@
+Class {
+	#name : 'CigPharoConstantsPoolGenerator',
+	#superclass : 'CigPharoGenerator',
+	#instVars : [
+		'generatedClass'
+	],
+	#category : 'CIG-Pharo-Generator',
+	#package : 'CIG',
+	#tag : 'Pharo-Generator'
+}
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator class >> constantsTemplate [
+
+	^ '
+#define fmt_spec(x) _Generic((x), \
+    int: "%d", \
+    unsigned int: "%u", \
+    long: "%ld", \
+    unsigned long: "%lu", \
+    long long: "%lld", \
+    unsigned long long: "%llu", \
+    short: "%hd", \
+    unsigned short: "%hu", \
+    signed char: "%hhd", \
+    unsigned char: "%hhu", \
+    char: "%c", \
+    float: "%f", \
+    double: "%f", \
+    long double: "%Lf", \
+    char *: "%s", \
+    const char *: "%s", \
+    default: "<unknown type>")
+#define type_name(x) _Generic((x), \
+    int: "int", \
+    unsigned int: "unsigned int", \
+    long: "long", \
+    unsigned long: "unsigned long", \
+    long long: "long long", \
+    unsigned long long: "unsigned long long", \
+    short: "short", \
+    unsigned short: "unsigned short", \
+    signed char: "Character", \
+    unsigned char: "Character", \
+    char: "Character", \
+    float: "float", \
+    double: "double", \
+    long double: "long double", \
+    char *: "String", \
+    const char *: "String", \
+    default: "unknown")
+#define print_macro(x) \
+    do { \
+        printf("%s:", #x); \
+        printf(fmt_spec((x)+0), (x)+0); \
+        printf(":%s\n", type_name((x)+0)); \
+    } while (0)
+'
+]
+
+{ #category : 'generating' }
+CigPharoConstantsPoolGenerator >> addClassAccessors: aCollection [
+
+	aCollection do: [ :each | 
+		self generatedClass class 
+			compileSilently: ('{1}
+
+	^ {1}' format: { each })
+			classified: 'accessing' ]
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> addClassInitializationMethodConstants: aDictionary [
+
+	generatedClass class 
+		compile: (self classInitializationTemplate: aDictionary)
+		classified: 'class initialization'.
+		
+	generatedClass initialize
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> addClassWithConstants: aCollection [
+	| typesName |
+
+	typesName := self libraryConstantsName.
+	generatedClass := SharedPool << typesName asSymbol
+		sharedVariables: (self collectSharedVariables: aCollection); 
+		tag: 'Library';
+		package: self packageName;
+		install
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> classInitializationTemplate: aDictionary [
+
+	^ String streamContents: [ :stream |
+		stream << 'initialize'; cr; cr.
+		aDictionary associations 
+			do: [ :assoc | 
+				stream tab.
+				stream <<  assoc key << ' := '.
+				stream print: assoc value ]
+			separatedBy: [ stream << '.'; cr ] ]
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> collectConstantValues: aCollection [
+	"
+	1. generate temporal file and compile it, get results.
+	2. parse and collect results into a dictionary.
+	"
+	| macros fileReference binaryReference result |
+
+	logger trace: aCollection.
+
+	macros := OrderedDictionary new.
+	fileReference := self generateCFileWith: aCollection.
+	binaryReference := self compileCFile: fileReference.
+	result := LibC resultOfCommand: binaryReference fullName.
+
+	result trimmed linesDo: [ :each | 
+		| tuple macroName |
+		tuple := each substrings: ':'.
+		macroName := tuple first.
+		tuple third ~= 'unknown'
+			ifTrue: [
+				logger trace: macroName message: 'ADD'.
+				macros 
+					at: macroName 
+					put: (self convert: tuple second to: tuple third) ] 
+			ifFalse: [
+				logger trace: macroName message: 'SKIP' ] ].
+	
+	^ macros
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> collectSharedVariables: aCollection [
+		
+	^ aCollection 
+		collect: [ :each | each asSymbol ] 
+		as: Array
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> compileCFile: fileReference [
+	| result binaryReference command |
+
+	logger trace: fileReference.
+
+	binaryReference := fileReference withoutExtension ensureDelete.
+	command := 'clang -std=c11 -Wall {3} {1} -o {2}' format: { 
+		fileReference basename. 
+		binaryReference basename.
+		String streamContents: [ :stream |
+			self file cIncludePathsAsArguments
+				do: [ :each | stream << each ] 
+				separatedBy: [ stream space ] ] }.
+	logger trace: command.
+	result := LibC resultOfCommand: ('cd {1} && {2}' format: { 
+		fileReference parent fullName. 
+		command }).
+	logger trace: result.
+
+	^ binaryReference
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> convert: aString to: typeString [
+
+	typeString = 'String' ifTrue: [ ^ aString ].
+	
+	^ aString asNumber
+]
+
+{ #category : 'generating' }
+CigPharoConstantsPoolGenerator >> generate [
+
+	^ self addClassWithConstants: #()
+]
+
+{ #category : 'private' }
+CigPharoConstantsPoolGenerator >> generateCFileWith: aCollection [
+	| fileReference |
+
+	fileReference := (FileLocator imageDirectory 
+		/ 'CIG' 
+		/ self file libraryName 
+		/ (self file libraryName, '_constants')) 
+		withExtension: 'c'.
+	fileReference parent ensureCreateDirectory.
+	
+	fileReference 
+		ensureDelete;
+		writeStreamDo: [ :stream | 
+
+			stream << '#import <stdio.h>'; lf.
+			
+			self file constantGenerator headers
+				ifNotNil: [ :aCollection | 
+					aCollection 
+						do: [ :each | stream << '#import <' << each << '>' ]
+						separatedBy: [ stream lf ] ]
+				ifNil: [
+					self file imports 
+						do: [ :eachTarget | 
+							eachTarget isUnit 
+								ifTrue: [ stream << eachTarget unit ]
+								ifFalse: [ stream << '#import <' << eachTarget name << '>' ] ]
+						separatedBy: [ stream lf ] ].
+
+			stream << self class constantsTemplate; lf.
+			
+			stream << 'int main() {'; lf.
+			aCollection 
+				do: [ :each | 
+					stream tab. 
+					stream << 'print_macro(' << each << ');'; lf ] .
+			stream tab; << 'return 0;'; lf.
+			stream << '}'; lf ].
+
+	^ fileReference
+]
+
+{ #category : 'generating' }
+CigPharoConstantsPoolGenerator >> generateConstants: aCollection [
+	| macros |
+
+	macros := self collectConstantValues: aCollection.
+	macros ifEmpty: [ ^ self ].
+	
+	self addClassWithConstants: macros keys sorted.
+	self addClassInitializationMethodConstants: macros.
+	self addClassAccessors: macros keys
+]
+
+{ #category : 'accessing' }
+CigPharoConstantsPoolGenerator >> generatedClass [
+
+	^ generatedClass
+]

--- a/src/CIG/CigPharoConstantsPoolGenerator.class.st
+++ b/src/CIG/CigPharoConstantsPoolGenerator.class.st
@@ -28,32 +28,13 @@ CigPharoConstantsPoolGenerator class >> constantsTemplate [
     float: "%f", \
     double: "%f", \
     long double: "%Lf", \
-    char *: "%s", \
-    const char *: "%s", \
+    char *: "\"%s\"", \
+    const char *: "\"%s\"", \
     default: "<unknown type>")
-#define type_name(x) _Generic((x), \
-    int: "int", \
-    unsigned int: "unsigned int", \
-    long: "long", \
-    unsigned long: "unsigned long", \
-    long long: "long long", \
-    unsigned long long: "unsigned long long", \
-    short: "short", \
-    unsigned short: "unsigned short", \
-    signed char: "Character", \
-    unsigned char: "Character", \
-    char: "Character", \
-    float: "float", \
-    double: "double", \
-    long double: "long double", \
-    char *: "String", \
-    const char *: "String", \
-    default: "unknown")
 #define print_macro(x) \
     do { \
-        printf("%s:", #x); \
+        printf("%s=", #x); \
         printf(fmt_spec((x)+0), (x)+0); \
-        printf(":%s\n", type_name((x)+0)); \
     } while (0)
 '
 ]
@@ -126,17 +107,14 @@ CigPharoConstantsPoolGenerator >> collectConstantValues: aCollection [
 	result := self executeCommand: binaryReference.
 
 	result trimmed linesDo: [ :each | 
-		| tuple macroName |
-		tuple := each substrings: ':'.
-		macroName := tuple first.
-		tuple third ~= 'unknown'
-			ifTrue: [
-				logger trace: macroName message: 'ADD'.
-				macros 
-					at: macroName 
-					put: (self convert: tuple second to: tuple third) ] 
-			ifFalse: [
-				logger trace: macroName message: 'SKIP' ] ].
+		| macroName macroValue |
+		
+		macroName := each copyUpTo: $=.
+		macroValue := each allButFirst: macroName size + 1.
+		logger trace: macroName.
+		macros 
+			at: macroName 
+			put: (self convert: macroValue) ].
 	
 	^ macros
 ]
@@ -170,10 +148,11 @@ CigPharoConstantsPoolGenerator >> compileCFile: fileReference [
 ]
 
 { #category : 'private' }
-CigPharoConstantsPoolGenerator >> convert: aString to: typeString [
+CigPharoConstantsPoolGenerator >> convert: aString [
 
-	typeString = 'String' ifTrue: [ ^ aString ].
-	
+	aString first = $" ifTrue: [
+		^ aString copyFrom: 2 to: (aString size - 1) ].
+
 	^ aString asNumber
 ]
 

--- a/src/CIG/CigPharoGenerator.class.st
+++ b/src/CIG/CigPharoGenerator.class.st
@@ -147,6 +147,25 @@ CigPharoGenerator >> libraryClass [
 ]
 
 { #category : 'private' }
+CigPharoGenerator >> libraryConstantsClass [
+
+	^ self class environment classNamed: self libraryConstantsName
+]
+
+{ #category : 'private' }
+CigPharoGenerator >> libraryConstantsName [
+	| prefix name |
+
+	prefix := self prefix.
+	name := self file libraryName capitalized.
+	^ String streamContents: [ :stream |
+		(name asLowercase beginsWith: prefix asLowercase)
+			ifFalse: [ stream << prefix capitalized ].
+		stream << name.
+		stream << 'Constants' ]
+]
+
+{ #category : 'private' }
 CigPharoGenerator >> libraryName [
 
 	^ 'Lib', self file libraryName capitalized
@@ -210,7 +229,9 @@ CigPharoGenerator >> sharedPoolNames [
 		((self unit namespaces collect: #typedef as: Set)
 			sorted: #name ascending)
 			do: [ :each | stream nextPut: each name ].
-		stream nextPut: self libraryTypedefName asSymbol ]
+		stream nextPut: self libraryTypedefName asSymbol.
+		self file hasConstants 
+			ifTrue: [ stream nextPut: self libraryConstantsName asSymbol ] ]
 ]
 
 { #category : 'accessing' }

--- a/src/CIG/CigPharoVisitor.class.st
+++ b/src/CIG/CigPharoVisitor.class.st
@@ -6,6 +6,7 @@ Class {
 	#name : 'CigPharoVisitor',
 	#superclass : 'CigVisitor',
 	#instVars : [
+		'constants',
 		'types',
 		'initializationRegistry'
 	],
@@ -18,14 +19,28 @@ Class {
 CigPharoVisitor >> addBaseClasses: aUnit [
 
 	self addFFITypesClass: aUnit.
+	self file hasConstants 
+		ifTrue:[ self addFFIConstantsClass: aUnit ].
 	self addFFILibrary: aUnit.
 	self addFFITrait: aUnit
+]
+
+{ #category : 'private' }
+CigPharoVisitor >> addDeclaredConstants: aUnit [
+
+	(CigPharoConstantsPoolGenerator newFile: self file unit: aUnit) generateConstants: self constants
 ]
 
 { #category : 'private' }
 CigPharoVisitor >> addDeclaredTypesToTypedef: aUnit [
 
 	(CigPharoTypesPoolGenerator newFile: self file unit: aUnit) generateTypes: self types
+]
+
+{ #category : 'private' }
+CigPharoVisitor >> addFFIConstantsClass: aUnit [
+	
+	(CigPharoConstantsPoolGenerator newFile: self file unit: aUnit) generate
 ]
 
 { #category : 'private' }
@@ -55,6 +70,12 @@ CigPharoVisitor >> addVariadicDeclarations: aUnit [
 ]
 
 { #category : 'private' }
+CigPharoVisitor >> constants [
+
+	^ constants
+]
+
+{ #category : 'private' }
 CigPharoVisitor >> disableRegisterChangesDuring: aBlock [
 	| monitor |
 
@@ -68,6 +89,7 @@ CigPharoVisitor >> disableRegisterChangesDuring: aBlock [
 CigPharoVisitor >> endUnit: aUnit [
 
 	self addDeclaredTypesToTypedef: aUnit.
+	self addDeclaredConstants: aUnit.
 	self executeInitializations
 ]
 
@@ -146,6 +168,7 @@ CigPharoVisitor >> registerType: anElement [
 CigPharoVisitor >> reset [
 
 	types := OrderedDictionary new.
+	constants := OrderedCollection new.
 	initializationRegistry := OrderedCollection new
 ]
 
@@ -212,6 +235,15 @@ CigPharoVisitor >> visitFunction: aFunction [
 		ifTrue: [ ^ self ].
 
 	(CigPharoFunctionGenerator newFile: self file element: aFunction) generateOn: self
+]
+
+{ #category : 'visiting' }
+CigPharoVisitor >> visitMacroDefinition: aMacroDefinition [
+
+	aMacroDefinition isPrintable ifFalse: [ ^ self ].
+	(self file constantGenerator isPrintable: aMacroDefinition) ifFalse: [ ^ self ].
+	
+	constants add: aMacroDefinition name
 ]
 
 { #category : 'visiting' }

--- a/src/CIG/CigTranslatedUnit.class.st
+++ b/src/CIG/CigTranslatedUnit.class.st
@@ -59,14 +59,17 @@ CigTranslatedUnit >> addNode: currentNode parent: parentNode [
 
 	parent := self findParent: parentNode.
 	(self findNode: currentNode startingAt: parent ifAbsent: [ nil ]) 
-		ifNotNil: [ ^ self ]. 
+		ifNotNil: [ ^ nil ]. 
 
 	element := self newNode: currentNode.
 	(element isUnknown and: [ self isGeneratingWithUnknown not ])
-		ifTrue: [ ^ self ].
+		ifTrue: [ ^ nil ].
 
-	(element canBeAddedTo: parent) ifFalse: [ ^ self ].
-	parent addElement: element
+	(element canBeAddedTo: parent) ifFalse: [ ^ nil ].
+	
+	parent addElement: element.
+	
+	^ element
 ]
 
 { #category : 'accessing' }
@@ -273,7 +276,7 @@ CigTranslatedUnit >> generateTarget: aTarget from: aHeader [
 						ifInsert: [ self insertNode: current ].
 					CXChildVisit recurse ]
 				ifFalse: [
-					logger trace: current displayName message: 'skipped'.
+					logger trace: current displayName message: 'SKIP'.
 					CXChildVisit continue ] ]
 		on: Error 
 		fork: [ :e | e pass ] 
@@ -344,10 +347,11 @@ CigTranslatedUnit >> insertNode: aCursor [
 	"inserts an element. 
 	 oposite to #addElement: it inserts it in its path, by creating namespaces between the 
 	 root at the element if needed."
-
 	| element |
+	
 	element := self newNode: aCursor.
-	self insertElement: element at: aCursor semanticParent semanticPath
+	self insertElement: element at: aCursor semanticParent semanticPath.
+	^ element
 ]
 
 { #category : 'inspecting' }
@@ -480,7 +484,7 @@ CigTranslatedUnit >> name [
 	^ '__Unit__'
 ]
 
-{ #category : 'general' }
+{ #category : 'accessing' }
 CigTranslatedUnit >> nameFor: anElement [
 
 	^ self nameGenerator visit: anElement
@@ -502,7 +506,6 @@ CigTranslatedUnit >> namespaces [
 CigTranslatedUnit >> newNode: currentNode [
 	
 	^ (self nodeClassAt: currentNode kind) fromCursor: currentNode
-		
 ]
 
 { #category : 'generating' }
@@ -515,11 +518,10 @@ CigTranslatedUnit >> newTranslateUnitFromFile: aTarget header: aHeader [
 		parseIndex: index 
 		fileName: fileName
 		arguments: (self collectArgumentsFrom: aHeader)
-		recordPreprocessor: aHeader hasPreprocessor.
+		recordPreprocessor: aHeader hasConstants.
 		
 	self flag: #TODO. "Make an abstraction for this" 
 	^ { fileName. index. unit }
-	
 ]
 
 { #category : 'generating' }

--- a/src/CIG/CigVisitor.class.st
+++ b/src/CIG/CigVisitor.class.st
@@ -79,6 +79,10 @@ CigVisitor >> visitFunction: aFunction [
 ]
 
 { #category : 'visiting' }
+CigVisitor >> visitMacroDefinition: aMacroDefinition [
+]
+
+{ #category : 'visiting' }
 CigVisitor >> visitMethod: aMethod [
 ]
 


### PR DESCRIPTION
you now have a mechanism to extract constants from the project headers.

closes #18 

# On Constants

Many libraries define their own constants as part of their conventions for writing code. For example, `libarchive` uses the macro `ARCHIVE_OK` to indicate a successful operation.  
While sometimes it's easy to identify and replace these constants (for instance, it's commonly known that `OK` usually maps to zero), this is one of the simpler cases. When working with more complex libraries, the situation can become more intricate. Continuing with the `libarchive` example, we find a wide range of definitions we might want to use—from formats and processes (e.g., `ARCHIVE_FORMAT_TAR`, `ARCHIVE_FORMAT_ZIP`) to file types encountered in archives (e.g., `AE_SYMLINK_TYPE_FILE`, `AE_SYMLINK_TYPE_DIRECTORY`).  
As libraries grow more complex, it becomes clear that asking users to manually look up the meaning of each constant in header files is not a sustainable approach.    
This is why we are introducing a constant generation mechanism, which attempts to extract relevant constants from header files and include them as part of the source generation process.  
However, this is not as straightforward as simply retrieving a cursor value using `libclang`. We need the full preprocessing capabilities of the `clang` compiler, along with some hacks provided by its extensions (which go beyond standard C). Without going into too much detail, the process works as follows:

1. We collect macro definitions while traversing the AST with `libclang` (excluding macros we can't support, such as function-like macros).
2. We generate and compile a file that outputs a list of `MACRO=VALUE` pairs.
3. We parse this output to retrieve the values.
4. We proceed with the regular source generation flow.

Obviously, this process may fail or produce unusable results. If that happens, the generator will raise an exception when it detects a problem—although it's still possible that some edge cases slip through. It is the responsibility of the recipe author to iterate on the process using the tools we provide (primarily by excluding problematic macros).
## How It Works

The simplest way to enable constant extraction is to send the `withConstants` message to your recipe:

```smalltalk
CigCLibraryGenerator new 
	withConstants;
	... etc...
```

If everything goes well, a `SharedPool` will be generated with the extracted macros.  
If not, you’ll need to customize the extraction process. Currently, we support two main options: `include:` and `excludeMacro:`.

```smalltalk
CigCLibraryGenerator new 
	constantGenerator: (CigConstantGenerator new 
		include: 'archive.h';
		excludeMacro: '__LA_DEPRECATED';
		yourself);
	... etc...
```

- `include:` specifies which header(s) should be used for macro extraction. This overrides the default headers inferred from the top-level recipe. It's especially useful when you're not using `import:` in your recipe  (e.g. using `importUnit:`).
- `excludeMacro:` tells the generator to skip the specified macro during extraction. This is useful for filtering out deprecated or unsupported macros.
